### PR TITLE
docs: update for links to doc and contribution in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <div align="center">
 
-📚 [Docs](https://developers.storipress.com) | 🗣 [Slack](https://join.slack.com/t/storipresscommunity/shared_invite/zt-1krx5nm1d-h_WKy1XF3MSxuY4BQ0VRbQ) | 💬 [Discussions](https://github.com/storipress/karbon/discussions) | 📝 [Changelog](./packages/karbon/CHANGELOG.md)
+📚 [Docs][documentation] | 🗣 [Slack](https://join.slack.com/t/storipresscommunity/shared_invite/zt-1krx5nm1d-h_WKy1XF3MSxuY4BQ0VRbQ) | 💬 [Discussions](https://github.com/storipress/karbon/discussions) | 📝 [Changelog][changelog]
 
 </div>
 
@@ -29,7 +29,7 @@
 - 😱 Instantly generate collection pages (i.e. category pages, brand pages)
 - 😤 [No AMP]() — ok, you can use AMP if you _really_ want, _[but you really don't need to](https://plausible.io/blog/google-amp)_
 - 🔦 Instant-search, baked in
-- And [a bunch more](https://developers.storipress.com)
+- And [a bunch more][documentation]
 
 Spin up a Karbon app in your browser with our [playground](https://karbon.new/) or set up your local environment with the instructions below ⬇️
 
@@ -69,12 +69,16 @@ npm run dev
 
 2. Visit the development environment running at http://localhost:3000.
 
-Learn more about [getting started with Karbon](https://developers.storipress.com).
+Learn more about [getting started with Karbon][documentation].
 
 ## Contributing to Karbon
 
-[Read our contributing guide](./.github/contributing.md)
+[Read our contributing guide][contributing]
 
 ## Other handy links
 
-[Learn more about Karbon](https://developers.storipress.com).
+[Learn more about Karbon][documentation].
+
+[contributing]: CONTRIBUTING.md
+[changelog]: CHANGELOG.md
+[documentation]: https://developers.storipress.com

--- a/packages/create-karbon/README.md
+++ b/packages/create-karbon/README.md
@@ -19,7 +19,7 @@ Create a new Karbon app in seconds.
 - 😱 Instantly generate collection pages (i.e. category pages, brand pages)
 - 😤 [No AMP]() — ok, you can use AMP if you _really_ want, _[but you really don't need to](https://plausible.io/blog/google-amp)_
 - 🔦 Instant-search, baked in
-- And [a bunch more](https://developers.storipress.com)
+- And [a bunch more][documentation]
 
 Spin up a Karbon app in your browser with our [playground](https://karbon.new/) or set up your local environment with the instructions below ⬇️
 
@@ -59,14 +59,16 @@ npm run dev
 
 2. Visit the development environment running at http://localhost:3000.
 
-Learn more about [getting started with Karbon](https://docs.storipress.com).
+Learn more about [getting started with Karbon][documentation].
 
 ## Contributing to Karbon
 
-[Read our contributing guide](./.github/contributing.md)
+[Read our contributing guide](/CONTRIBUTING.md)
 
 ## Other handy links
 
-[Learn more about Karbon](https://storipress.com/karbon).
+[Learn more about Karbon][documentation].
 
 👷‍♀️ Add `npm` packages to your project:
+
+[documentation]: https://developers.storipress.com

--- a/packages/karbon/README.md
+++ b/packages/karbon/README.md
@@ -8,7 +8,7 @@
 
 <div align="center">
 
-📚 [Docs](https://developers.storipress.com) | 🗣 [Slack](https://join.slack.com/t/storipresscommunity/shared_invite/zt-1krx5nm1d-h_WKy1XF3MSxuY4BQ0VRbQ) | 💬 [Discussions](https://github.com/storipress/karbon/discussions) | 📝 [Changelog](./packages/karbon/CHANGELOG.md)
+📚 [Docs][documentation] | 🗣 [Slack](https://join.slack.com/t/storipresscommunity/shared_invite/zt-1krx5nm1d-h_WKy1XF3MSxuY4BQ0VRbQ) | 💬 [Discussions](https://github.com/storipress/karbon/discussions) | 📝 [Changelog][changelog]
 
 </div>
 
@@ -29,7 +29,7 @@
 - 😱 Instantly generate collection pages (i.e. category pages, brand pages)
 - 😤 [No AMP]() — ok, you can use AMP if you _really_ want, _[but you really don't need to](https://plausible.io/blog/google-amp)_
 - 🔦 Instant-search, baked in
-- And [a bunch more](https://developers.storipress.com)
+- And [a bunch more][documentation]
 
 Spin up a Karbon app in your browser with our [playground](https://karbon.new/) or set up your local environment with the instructions below ⬇️
 
@@ -69,16 +69,17 @@ npm run dev
 
 2. Visit the development environment running at http://localhost:3000.
 
-Learn more about [getting started with Karbon](https://docs.storipress.com).
+Learn more about [getting started with Karbon][documentation].
 
 ## Contributing to Karbon
 
-[Read our contributing guide](./.github/contributing.md)
+[Read our contributing guide](/CONTRIBUTING.md)
 
 ## Other handy links
 
-[Learn more about Karbon](https://storipress.com/karbon).
+[Learn more about Karbon][documentation].
 
 👷‍♀️ Add `npm` packages to your project:
 
--
+[changelog]: CHANGELOG.md
+[documentation]: https://developers.storipress.com


### PR DESCRIPTION
Found a few broken links in the markdown files of the project and tried to fix them.

- made use of link labels in readmes so changing links to documentation only need one change per file (DRY)
- fixed the links to CONTRIBUTING.md in the readmes (404 before)
- fixed the links to documentation in the readmes for two packages (https://docs.storipress.com and https://storipress.com/karbon gave 404)
- fixed the link to /CHANGELOG.md in /README.md (it should not point to the CHANGELOG.md in /packages/karbon/ , right?)

Not sure, if /packages/karbon/README.md should better link to /CHANGELOG.md instead of /packages/karbon/CHANGELOG.md as the later is not up2date?