### PR TITLE
feat: check node version in yarn karbon and module.ts

### DIFF
--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/storipress/karbon"
   },
+  "engines": {
+    "node": ">=16.7.0"
+  },
   "main": "./dist/index.mjs",
   "exports": {
     ".": {

--- a/packages/jose-browser/package.json
+++ b/packages/jose-browser/package.json
@@ -7,6 +7,9 @@
   "bugs": {
     "url": "https://github.com/storipress/karbon"
   },
+  "engines": {
+    "node": ">=16.7.0"
+  },
   "files": [
     "./dist"
   ],

--- a/packages/karbon/package.json
+++ b/packages/karbon/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/storipress/karbon"
   },
+  "engines": {
+    "node": ">=16.7.0"
+  },
   "exports": {
     ".": {
       "import": "./dist/module.mjs",

--- a/packages/karbon/src/cli/checkFile/index.ts
+++ b/packages/karbon/src/cli/checkFile/index.ts
@@ -40,8 +40,18 @@ async function typeSafe() {
   }
 }
 
+export function versionSafe() {
+  const version = process.version
+  const major = Number(version.split('.')[0].replace('v', ''))
+  const minor = Number(version.split('.')[1])
+  if ((major === 16 && minor < 17) || major < 16) {
+    consola.warn(karbonMsg.versionWarning)
+  }
+}
+
 export async function checkFile(siteTemplateName: string) {
   fileName = siteTemplateName
+  versionSafe()
   await typeSafe()
   jsonSafe()
 }

--- a/packages/karbon/src/cli/checkFile/setting.ts
+++ b/packages/karbon/src/cli/checkFile/setting.ts
@@ -6,6 +6,7 @@ export enum karbonMsg {
   layoutsPosError = 'Cannot find Bundled layouts files.',
   uploadError = 'upload failed',
   compressingError = 'compressing failed',
+  versionWarning = 'Your node version is too low, please upgrade to v16.17.0 or higher.',
 }
 export const safeExt = 'zip'
 export const extErrorMsg = `File extension is not ${safeExt}`

--- a/packages/karbon/src/module.ts
+++ b/packages/karbon/src/module.ts
@@ -22,6 +22,7 @@ import fs from 'fs-extra'
 import { resolve } from 'pathe'
 import { genArrayFromRaw, genImport, genObjectFromRaw } from 'knitwork'
 import { resolveSEOProviders } from './seo-provider'
+import { versionSafe } from './cli/checkFile'
 import type {
   ArticleMeta,
   DeskMeta,
@@ -115,6 +116,8 @@ const karbon = defineNuxtModule<ModuleOptions>({
       'typesense-instantsearch-adapter',
       'qs',
     ]
+
+    versionSafe()
 
     nuxt.options.experimental.payloadExtraction = true
     nuxt.options.css.push(resolver.resolve('./runtime/assets/article-base.css'))


### PR DESCRIPTION
## Jira

[//]: # 'This template is for new features, or changing an existing feature'

[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has description for the feature'

https://storipress-media.atlassian.net/jira/software/projects/SPMVP/boards/1?selectedIssue=SPMVP-5119

## Purpose

[//]: # 'Please describe how the feature will affect user, e.g.'
[//]: # '- Allow to add link on image so publisher can directly link an image in static site'
[//]: # '- Adjust "Go to site" button to become "Go to Shopify" to let publisher using Shopify integration can directly go to see preview'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

If user node version below recommend version, will show warning message while in `yarn karbon`

### For who

- [ ] reader-facing?
- [ ] publisher-facing?
- [x] developer-facing?

## How did you make it?

[//]: # 'Give a brief for the changes you made'

check `process.version`

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

1.  use node version below v16.17
2. yarn postinstall & yarn karbon
3. check warning msg appear ⭕ 

## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the feature is working
- [x] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [x] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [x] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [x] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
