### PR TITLE
feat: lazy load paywall [SPMVP-5024]

### DIFF
--- a/packages/karbon/src/runtime/plugins/paywall.client.ts
+++ b/packages/karbon/src/runtime/plugins/paywall.client.ts
@@ -1,8 +1,16 @@
-import { mountPaywall, reactive, setStripeKey } from '@storipress/builder-component'
 import { useEventBus, useStorage } from '@vueuse/core'
 import { once } from 'lodash'
 import '@storipress/builder-component/dist/style.css'
-import { computed, defineNuxtPlugin, ref, useRouter, useRuntimeConfig, useSite, useSubscriberClient } from '#imports'
+import {
+  computed,
+  defineNuxtPlugin,
+  reactive,
+  ref,
+  useRouter,
+  useRuntimeConfig,
+  useSite,
+  useSubscriberClient,
+} from '#imports'
 import paywallLogo from '#build/paywall-logo'
 
 enum ArticlePlan {
@@ -19,8 +27,6 @@ interface Article {
 export default defineNuxtPlugin((_nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   const router = useRouter()
-
-  setStripeKey(runtimeConfig.storipress.stripeKey)
 
   const token = useStorage('storipress-token', '')
   const authInfo = ref<Record<string, any> | null | undefined>(null)
@@ -50,10 +56,12 @@ export default defineNuxtPlugin((_nuxtApp) => {
   })
 
   const { storipress } = runtimeConfig.public
-  const mount = once(() => {
-    if (typeof storipress.paywall === 'boolean' && !storipress.paywall) {
+  const mount = once(async () => {
+    if (!storipress.paywall.enable) {
       return
     }
+    const { mountPaywall, setStripeKey } = await import('@storipress/builder-component')
+    setStripeKey(runtimeConfig.storipress.stripeKey)
 
     const { push, currentRoute } = router
     const { fullPath, path, query } = currentRoute.value


### PR DESCRIPTION
## Jira
[SPMVP-5024](https://storipress-media.atlassian.net/browse/SPMVP-5024)

[//]: # 'This template is for new features, or changing an existing feature'

[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has description for the feature'

## Purpose
在有 mount paywall 時才載入 builder-component

[//]: # 'Please describe how the feature will affect user, e.g.'
[//]: # '- Allow to add link on image so publisher can directly link an image in static site'
[//]: # '- Adjust "Go to site" button to become "Go to Shopify" to let publisher using Shopify integration can directly go to see preview'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [ ] reader-facing?
- [ ] publisher-facing?
- [ ] developer-facing?

## How did you make it?


[//]: # 'Give a brief for the changes you made'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

1.
2.

## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [ ] I have done a self-review of my own code (comment on code is not required but recommended)
- [ ] I did the Tophat steps and confirm the feature is working
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [ ] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [ ] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)


[SPMVP-5024]: https://storipress-media.atlassian.net/browse/SPMVP-5024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ