### PR TITLE
mount paywall when setup page

### DIFF
--- a/packages/karbon/src/runtime/composables/page-meta.ts
+++ b/packages/karbon/src/runtime/composables/page-meta.ts
@@ -77,6 +77,7 @@ export function setupPage<Type extends PageType>({ type, seo = true }: SetupPage
     const { $paywall } = useNuxtApp()
     const { id, plan } = meta.value
     onMounted(() => {
+      $paywall.mount()
       $paywall.enable()
       $paywall.setArticle({ id, plan })
     })


### PR DESCRIPTION
## Purpose

Fix after reloading the article page, `paywall.mount()` in `app.vue` has not been called when `page-meta.ts` calls `paywall.enable()`