### PR TITLE
feat: support config page meta for resource templates

### DIFF
--- a/packages/karbon/package.json
+++ b/packages/karbon/package.json
@@ -168,7 +168,9 @@
     "vite": "^4.1.4",
     "vite-plugin-css-injected-by-js": "^3.0.1",
     "vite-tsconfig-paths": "^4.0.5",
+    "vue": "^3.2.47",
     "vue-instantsearch": "^4.8.7",
+    "vue-router": "^4.1.6",
     "vue3-lazy-hydration": "^1.2.1"
   },
   "devDependencies": {

--- a/packages/karbon/src/module.ts
+++ b/packages/karbon/src/module.ts
@@ -509,13 +509,15 @@ async function addResourcePage(pageType: keyof URLGenerators, urls: URLGenerator
   const resource = (resourceName || pageType) as string
   const pagePath = resolve(cwd, `templates/resources/${resource}.vue`)
   if (await fs.pathExists(pagePath)) {
+    const resourcePage = urls[resource]
     extendPages((pages) => {
       pages.push({
         file: pagePath,
-        path: urls[resource].route,
+        path: resourcePage.route,
         name: resource,
         meta: {
-          middleware: ['storipress-abort-if-no-meta'],
+          ...resourcePage.meta,
+          middleware: ['storipress-abort-if-no-meta', ...(resourcePage.meta?.middleware || [])],
           ...(resourceName && { resourceName }),
         },
       })

--- a/packages/karbon/src/runtime/types.ts
+++ b/packages/karbon/src/runtime/types.ts
@@ -1,8 +1,30 @@
+import type { KeepAliveProps, TransitionProps } from 'vue'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import type { NormalizeArticle } from './api/normalize-article'
 
 export type PayloadScope = 'posts' | 'tags' | 'desks' | 'authors'
 export type Resources = 'article' | 'desk' | 'tag' | 'author'
 export type Identity = 'id' | 'slug' | 'sid'
+
+// Copy from Nuxt page meta and remove some fields
+export interface PageMeta {
+  [key: string]: any
+  name: never
+  path: never
+
+  /**
+   * Aliases for the record. Allows defining extra paths that will behave like a
+   * copy of the record. Allows having paths shorthands like `/users/:id` and
+   * `/u/:id`. All `alias` and `path` values must share the same params.
+   */
+  alias?: string | string[]
+  pageTransition?: boolean | TransitionProps
+  layoutTransition?: boolean | TransitionProps
+  key?: false | string | ((route: RouteLocationNormalizedLoaded) => string)
+  keepalive?: boolean | KeepAliveProps
+  /** Set to `false` to avoid scrolling to top on page navigations */
+  scrollToTop?: boolean
+}
 
 export interface Identifiable {
   id: string
@@ -47,6 +69,7 @@ export interface ResourcePage<Meta extends Identifiable, Ctx = ResourcePageConte
   toURL(resource: Meta, _context: Ctx): string
   _context?: Ctx
   groupKey?: string
+  meta?: PageMeta
 }
 
 export interface BaseMeta {

--- a/packages/karbon/src/runtime/types.ts
+++ b/packages/karbon/src/runtime/types.ts
@@ -8,6 +8,7 @@ export type Identity = 'id' | 'slug' | 'sid'
 
 // Copy from Nuxt page meta and remove some fields
 export interface PageMeta {
+  // skipcq: JS-0323
   [key: string]: any
   name: never
   path: never

--- a/packages/karbon/src/url/index.ts
+++ b/packages/karbon/src/url/index.ts
@@ -1,4 +1,4 @@
-import type { BaseMeta, ResourcePage, Resources } from '../runtime/types'
+import type { BaseMeta, PageMeta, ResourcePage, Resources } from '../runtime/types'
 import { parse } from './parser'
 import { convertToOption } from './to-options'
 import type { RouteOptionsContext } from './types'
@@ -7,56 +7,65 @@ interface ResourceRouteOption {
   url: string
   resource: Resources
   groupKey?: string
+  meta?: PageMeta
   /**
    * @ignore
    */
   _staticParams?: Record<string, string>
 }
 
+type SimpleResourceRouteOption = Pick<ResourceRouteOption, 'meta'>
+
 export function createResourceRoute(opt: ResourceRouteOption): ResourcePage<BaseMeta, RouteOptionsContext> {
   return {
     ...convertToOption(opt.resource, parse(opt.url), opt._staticParams),
+    meta: opt.meta,
     groupKey: opt.groupKey,
   }
 }
 
-export function createArticleRoute(url: string) {
+export function createArticleRoute(url: string, opt: SimpleResourceRouteOption = {}) {
   const option: ResourceRouteOption = {
     resource: 'article',
     url,
+    ...opt,
   }
   return createResourceRoute(option)
 }
 
-export function createTagRoute(url: string) {
+export function createTagRoute(url: string, opt: SimpleResourceRouteOption = {}) {
   const option: ResourceRouteOption = {
     resource: 'tag',
     url,
+    ...opt,
   }
   return createResourceRoute(option)
 }
 
-export function createTagCollectionRoute(url: string, groupKey: string) {
+export function createTagCollectionRoute(url: string, groupKey: string, opt: SimpleResourceRouteOption = {}) {
   const option: ResourceRouteOption = {
     resource: 'tag',
     url,
     groupKey,
+    ...opt,
   }
   return createResourceRoute(option)
 }
 
-export function createDeskRoute(url: string) {
+export function createDeskRoute(url: string, opt: SimpleResourceRouteOption = {}) {
   const option: ResourceRouteOption = {
     resource: 'desk',
     url,
+    ...opt,
   }
   return createResourceRoute(option)
 }
 
-export function createAuthorRoute(url: string) {
+export function createAuthorRoute(url: string, opt: SimpleResourceRouteOption = {}) {
   const option: ResourceRouteOption = {
     resource: 'author',
     url,
+    ...opt,
   }
   return createResourceRoute(option)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,7 +3180,9 @@ __metadata:
     vite-plugin-css-injected-by-js: ^3.0.1
     vite-tsconfig-paths: ^4.0.5
     vitest: 0.29.8
+    vue: ^3.2.47
     vue-instantsearch: ^4.8.7
+    vue-router: ^4.1.6
     vue3-lazy-hydration: ^1.2.1
   bin:
     karbon: ./bin/karbon.mjs


### PR DESCRIPTION
## Jira

https://storipress-media.atlassian.net/browse/SPMVP-4594

## Purpose

As Karbon's resource template is essentially a Nuxt page, we have added an option to allow users to directly pass in page meta as a temporary workaround for `definePageMeta`.

This PR does not add support for `definePageMeta` in the resource template.

## How did you make it?

It allows helper functions such as `createResourceRoute` to pass partial `PageMeta` to `extendPages`.

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

1. pass `meta` in `resources` config
  <img width="717" alt="image" src="https://user-images.githubusercontent.com/5575082/232703431-35e7c73b-06ea-4d47-89fe-8b12e703f590.png">
2. verify the added meta in `route.meta` with devtool :o:
  <img width="346" alt="image" src="https://user-images.githubusercontent.com/5575082/232703330-5ba5f93a-3e11-4886-b1d3-1ef312b6727e.png">

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the feature is working
- [x] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [x] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [x] I confirmed that the unit test is passed (if you break it, please fix it in this PR)


## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
