### PR TITLE
[SPMVP-5377] karbon expose encrypt key to public config

### DIFF
--- a/packages/karbon/src/module.ts
+++ b/packages/karbon/src/module.ts
@@ -145,7 +145,7 @@ const karbon = defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig.public.storipress = {
       ...nuxt.options.runtimeConfig.public.storipress,
       searchDomain: 'search.stori.press',
-      ...omit(nuxt.options.runtimeConfig.storipress, ['apiToken', 'stripeKey']),
+      ...omit(nuxt.options.runtimeConfig.storipress, ['apiToken', 'stripeKey', 'encryptKey']),
       fullStatic,
       previewParagraph,
     }


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-5377

omit encryptKey in `runtimeConfig.public.storipress`

測試：
在 Karbon 網站中檢查 `__NUXT__.config.public.storipress.encryptKey` 內沒有值

<img width="867" alt="image" src="https://user-images.githubusercontent.com/37400982/235473596-bcf5f4b1-1750-4ead-a2ef-185fe60f1ec1.png">
