### PR TITLE
fix: subscription API uses wrong domain [SPMVP-5649]

### DIFF
--- a/packages/karbon/src/runtime/plugins/1.injectRuntimeConfig.ts
+++ b/packages/karbon/src/runtime/plugins/1.injectRuntimeConfig.ts
@@ -3,5 +3,5 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin((_nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
-  storipressConfigCtx.set(runtimeConfig.storipress)
+  storipressConfigCtx.set({ ...runtimeConfig.public.storipress, ...runtimeConfig.storipress })
 })

--- a/packages/karbon/src/runtime/plugins/storipress-client.ts
+++ b/packages/karbon/src/runtime/plugins/storipress-client.ts
@@ -1,7 +1,11 @@
 import { createStoripressClient, createSubscriberClient, storipressClientCtx } from '../composables/storipress-client'
-import { defineNuxtPlugin } from '#imports'
+import { storipressConfigCtx } from '../composables/storipress-base-client'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin((_nuxtApp) => {
+  const runtimeConfig = useRuntimeConfig()
+  storipressConfigCtx.set({ ...runtimeConfig.public.storipress, ...runtimeConfig.storipress })
+
   const apolloClient = createStoripressClient()
   const subscriberClient = createSubscriberClient()
 


### PR DESCRIPTION
## Jira
https://storipress-media.atlassian.net/browse/SPMVP-5649

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause
Create `SubscriberClient` 從 `storipressConfigCtx` 取 runtimeConfig 會是 `undefined`，導致 `apihost` 與 `clientId` 不正確

[//]: # 'Why the bug happen?'

## Purpose
訂閱功能沒有使用正確的 API 

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [ ] reader-facing?
- [x] publisher-facing?
- [ ] developer-facing?

## How did you fix it?
`1.injectRuntimeConfig` plugin 在 set `runtimeConfig` 時也傳入 `public.storipress`

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

note: Karbon 更新後須再至 [nuxt3-compatible-layer](https://github.com/storipress/nuxt3-compatible-layer) 確認 subscription 功能 

目前是先在 nuxt3-compatible-layer 直接調整 node module 的套件在 local 確認取得到 runtimeConfig 的 `apihost` 與 `clientId`
subscription 功能使用正確的 api ⭕ 

## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the issue fixed
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [ ] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [ ] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
