### PR TITLE
[SPMVP-5655] need to support slug in seo for desk

### DIFF
--- a/packages/karbon/src/runtime/api/desk.ts
+++ b/packages/karbon/src/runtime/api/desk.ts
@@ -7,10 +7,12 @@ const ListDesks = gql`
       id
       name
       slug
+      seo
       desks {
         id
         name
         slug
+        seo
       }
     }
   }
@@ -21,10 +23,12 @@ const GetDesk = gql`
       id
       name
       slug
+      seo
       desks {
         id
         name
         slug
+        seo
       }
       metafields {
         id

--- a/packages/karbon/src/runtime/plugins/storipress.ts
+++ b/packages/karbon/src/runtime/plugins/storipress.ts
@@ -32,6 +32,7 @@ const fetchMeta = defineNuxtRouteMiddleware(async (to) => {
   const urlKey = to.name
   const { resolveFromID: resolveID, _getContextFor } = useResourceResolver()
   const ctx = _getContextFor(urlKey)
+  // ref: https://github.com/storipress/karbon/pull/95
   const desksMeta = ctx.resource === 'desk' ? await loadStoripressPayload<DeskMeta[]>('desks', '__all') : undefined
   const resourceID = urls[urlKey].getIdentity(to.params as Record<string, string>, ctx, desksMeta)
   const res = await resolveID(resourceID, to.params as Record<string, string>, to.meta.resourceName as string)

--- a/packages/karbon/src/runtime/templates/storipress-urls.mjs.d.ts
+++ b/packages/karbon/src/runtime/templates/storipress-urls.mjs.d.ts
@@ -38,7 +38,7 @@ export interface ResourcePageContext {
 export interface ResourcePage<Meta extends Identifiable> {
   route: string
   enable: boolean
-  getIdentity(params: Record<string, string>, _context: ResourcePageContext): ResourceID
+  getIdentity(params: Record<string, string>, _context: ResourcePageContext, deskMetas?: Meta[]): ResourceID
   isValid(params: Record<string, string>, resource: Meta, _context: ResourcePageContext): boolean
   toURL(resource: Meta, _context: ResourcePageContext): string
   _context?: ResourcePageContext

--- a/packages/karbon/src/runtime/types.ts
+++ b/packages/karbon/src/runtime/types.ts
@@ -65,7 +65,7 @@ export interface ResourcePageContext {
 export interface ResourcePage<Meta extends Identifiable, Ctx = ResourcePageContext> {
   route: string
   enable: boolean
-  getIdentity(params: Record<string, string>, _context: Ctx): ResourceID
+  getIdentity(params: Record<string, string>, _context: Ctx, deskMetas?: Meta[]): ResourceID
   isValid(params: Record<string, string>, resource: Meta, _context: Ctx): boolean
   toURL(resource: Meta, _context: Ctx): string
   _context?: Ctx


### PR DESCRIPTION
為了處理 desk meta 可能需要使用 seo 資料的問題，在 resource 為 desk 的情況下將 desk meta 注入 `getIdentity`
https://storipress-media.atlassian.net/browse/SPMVP-5655

測試：
1. playground 可以正確取得 desk meta
2. yarn pack 後由使用 Karbon 的專案安裝並測試可以正確取得 desk meta