### PR TITLE
[SPMVP-5652] ignore import if the paywall logo is full URL

### DIFF
--- a/packages/karbon/src/runtime/plugins/paywall.client.ts
+++ b/packages/karbon/src/runtime/plugins/paywall.client.ts
@@ -62,11 +62,11 @@ export default defineNuxtPlugin((_nuxtApp) => {
     const { mountPaywall, setStripeKey } = await import('@storipress/builder-component')
     const paywallLogoPath = _nuxtApp.$config.public?.storipress?.paywall?.logo
     let paywallLogo
-    if (/^http/.test(paywallLogoPath)) {
+    if (paywallLogoPath.startsWith('http')) {
       paywallLogo = paywallLogoPath
     } else {
-      // @ts-expect-error
-      paywallLogo = await import('#build/paywall-logo')
+      // @ts-expect-error no type
+      paywallLogo = (await import('#build/paywall-logo')).default
     }
     setStripeKey(runtimeConfig.public.storipress.stripeKey)
 

--- a/packages/karbon/src/runtime/plugins/paywall.client.ts
+++ b/packages/karbon/src/runtime/plugins/paywall.client.ts
@@ -11,7 +11,6 @@ import {
   useSite,
   useSubscriberClient,
 } from '#imports'
-import paywallLogo from '#build/paywall-logo'
 
 enum ArticlePlan {
   Free = 'free',
@@ -61,6 +60,14 @@ export default defineNuxtPlugin((_nuxtApp) => {
       return
     }
     const { mountPaywall, setStripeKey } = await import('@storipress/builder-component')
+    const paywallLogoPath = _nuxtApp.$config.public?.storipress?.paywall?.logo
+    let paywallLogo
+    if (/^http/.test(paywallLogoPath)) {
+      paywallLogo = paywallLogoPath
+    } else {
+      // @ts-expect-error
+      paywallLogo = await import('#build/paywall-logo')
+    }
     setStripeKey(runtimeConfig.public.storipress.stripeKey)
 
     const { push, currentRoute } = router


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-5652

測試：
1. 分別設置相對路徑與完整網址，檢查 `plugins/paywall.client` 的 `paywallLogo` 正確對應
2. pack 至使用 Karbon 專案檢查 paywall 設置是否生效
![image](https://github.com/storipress/karbon/assets/37400982/3a7c5aec-4ef4-48bc-bbe2-248e005e71af)

