### PR TITLE
fix: full width image will move together when scrolling [SPMVP-5751]

### DIFF
--- a/packages/karbon/src/runtime/article/components/ArticleBody.vue
+++ b/packages/karbon/src/runtime/article/components/ArticleBody.vue
@@ -57,7 +57,7 @@ watch(
   },
 )
 
-const { left } = useElementBounding(root)
+const { left, width } = useElementBounding(root)
 const { render } = useRenderEditorBlock(editorBlocks)
 const customFieldsKey = CUSTOM_FIELD_EDITOR_BLOCK_KEY
 // @ts-expect-error internal untyped property
@@ -126,7 +126,7 @@ whenever(
 </script>
 
 <template>
-  <div ref="root" class="article-body" :style="{ '--left-offset': `${left}px` }">
+  <div ref="root" class="article-body" :style="{ '--left-offset': `${left}px`,'--body-width': `${width}px` }">
     <div v-for="(segment, index) of articleSegments" :key="`${segment.id}-${index}`">
       <AdvertisingSlot
         v-if="segment.type === 'ad'"

--- a/packages/karbon/src/runtime/article/components/ArticleBody.vue
+++ b/packages/karbon/src/runtime/article/components/ArticleBody.vue
@@ -126,7 +126,7 @@ whenever(
 </script>
 
 <template>
-  <div ref="root" class="article-body" :style="{ '--left-offset': `${left}px`,'--body-width': `${width}px` }">
+  <div ref="root" class="article-body" :style="{ '--left-offset': `${left}px`, '--body-width': `${width}px` }">
     <div v-for="(segment, index) of articleSegments" :key="`${segment.id}-${index}`">
       <AdvertisingSlot
         v-if="segment.type === 'ad'"

--- a/packages/karbon/src/runtime/assets/article-base.scss
+++ b/packages/karbon/src/runtime/assets/article-base.scss
@@ -10,7 +10,7 @@
       @apply px-0;
 
       margin-left: calc(var(--left-offset, 0) * -1);
-      width: 100vw;
+      width: var(--body-width);
     }
 
     &.wide {


### PR DESCRIPTION
## Jira
https://storipress-media.atlassian.net/browse/SPMVP-5751

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause
圖片滿版時的寬度設定為 `100vw` 導致捲軸出現

[//]: # 'Why the bug happen?'

## Purpose
修正文章圖片滿版時會超出右邊且可以捲動的問題

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [x] reader-facing?
- [ ] publisher-facing?
- [ ] developer-facing?

## How did you fix it?
取得 body width 並設為圖片滿版時的寬度

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

test in local

1. Update kanbon in local (run `yarn postinstall`)
2. cd package/playground and run `yarn dev`
3. Go to the article page with full width image (test in http://localhost:3000/posts/599)
4. No horizontal scrolling ⭕ 

## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the issue fixed
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [x] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [x] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
