### PR TITLE
fix: subscriber login may fail occasionally due to lazy-loaded paywall [SPMVP-6255]

### DIFF
--- a/packages/karbon/src/runtime/composables/page-meta.ts
+++ b/packages/karbon/src/runtime/composables/page-meta.ts
@@ -83,8 +83,8 @@ export function setupPage<Type extends PageType>({ type, seo = true }: SetupPage
 
   if (type === 'article') {
     const { $paywall } = useNuxtApp()
-    onMounted(() => {
-      $paywall.mount()
+    onMounted(async () => {
+      await $paywall.mount()
       $paywall.enable()
 
       whenever(

--- a/packages/karbon/src/runtime/plugins/paywall.client.ts
+++ b/packages/karbon/src/runtime/plugins/paywall.client.ts
@@ -27,6 +27,7 @@ interface Article {
 export default defineNuxtPlugin((_nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   const router = useRouter()
+  const route = useRoute()
 
   const token = useStorage('storipress-token', '')
   const authInfo = ref<Record<string, any> | null | undefined>(null)
@@ -60,7 +61,10 @@ export default defineNuxtPlugin((_nuxtApp) => {
     if (!storipress.paywall.enable) {
       return
     }
-    await waitFirstInteractive()
+    const { action, token } = route.query
+    if (!(action === 'sign-in' && token)) {
+      await waitFirstInteractive()
+    }
     const { mountPaywall, setStripeKey } = await import('@storipress/builder-component')
     const paywallLogoPath = _nuxtApp.$config.public?.storipress?.paywall?.logo
     let paywallLogo

--- a/packages/karbon/src/runtime/plugins/paywall.client.ts
+++ b/packages/karbon/src/runtime/plugins/paywall.client.ts
@@ -7,6 +7,7 @@ import {
   defineNuxtPlugin,
   reactive,
   ref,
+  useRoute,
   useRouter,
   useRuntimeConfig,
   useSite,
@@ -61,8 +62,8 @@ export default defineNuxtPlugin((_nuxtApp) => {
     if (!storipress.paywall.enable) {
       return
     }
-    const { action, token } = route.query
-    if (!(action === 'sign-in' && token)) {
+    const { action, token: tokenQuery } = route.query
+    if (!(action === 'sign-in' && tokenQuery)) {
       await waitFirstInteractive()
     }
     const { mountPaywall, setStripeKey } = await import('@storipress/builder-component')

--- a/packages/playground/app.vue
+++ b/packages/playground/app.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 const { $paywall } = useNuxtApp()
 
-onMounted(() => {
-  $paywall.mount()
+onMounted(async () => {
+  await $paywall.mount()
   $paywall.checkQuery()
 })
 


### PR DESCRIPTION
## Jira
https://storipress-media.atlassian.net/browse/SPMVP-6255

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause
paywall plugin 因為 speed test 有設置 `waitFirstInteractive` 等待使用者第一次與瀏覽器有互動時才會載入
因為 paywall 在使用者第一次與瀏覽器有互動時才會載入，可能使用者在登入導回頁面時如果一直未與瀏覽器互動而導致 paywall 未載入不會接著執行 check query 及 login badge 不會出現在頁面上

[//]: # 'Why the bug happen?'

## Purpose
如果有登入相關的 query，直接載入 paywall 讓使用者盡早變成登入狀態

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [x] reader-facing?
- [ ] publisher-facing?
- [ ] developer-facing?

## How did you fix it?
偵測使用者如果是在執行登入的行為，直接載入 paywall

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

1. Paste login query
2. Paywall 有直接載入 ⭕ 

## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the issue fixed
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [ ] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [ ] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
