### PR TITLE
fix: template not using seo meta description

### DIFF
--- a/packages/karbon/src/runtime/composables/seo.ts
+++ b/packages/karbon/src/runtime/composables/seo.ts
@@ -43,7 +43,7 @@ function createFirstFound(paths: string[][]) {
 }
 
 const TITLE = [['seo', 'meta', 'title'], ['title']]
-const DESCRIPTION = [['description'], ['plaintext']]
+const DESCRIPTION = [['seo', 'meta', 'description'], ['plaintext']]
 const OG_TITLE = [['seo', 'og', 'title'], ...TITLE]
 const OG_DESCRIPTION = [['seo', 'og', 'description'], ...DESCRIPTION]
 const OG_IMAGE = [['seo', 'ogImage'], ['headline'], ['cover', 'url']]


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6223

原因：
問題不在 Shopify site 而是 Karbon
SEO DESCRIPTION 的 path 錯誤
導致無法正確取得 seo meta description 而使用 plaintext


<img width="749" alt="image" src="https://github.com/storipress/karbon/assets/37400982/bf977a13-fb8a-4de8-8ce1-19df339746a4">

<img width="709" alt="image" src="https://github.com/storipress/karbon/assets/37400982/5ef9756c-ac57-4981-97b4-9bcde352519b">
