### PR TITLE
fix: prepend siteCDN URL to API endpoint for Shopify site

### DIFF
--- a/packages/karbon/src/runtime/composables/decrypt-client.ts
+++ b/packages/karbon/src/runtime/composables/decrypt-client.ts
@@ -7,8 +7,9 @@ export function useDecryptClient<T>() {
   return (key: string) => {
     // encode as base64 to prevent error in http header
     const auth = btoa(JSON.stringify(nuxt.$paywall.authInfo.value))
+    const siteCDN = runtimeConfig.public?.siteCDN || ''
     return runtimeConfig.public?.storipress?.paywall?.enable
-      ? ($fetch('/api/decrypt-key', {
+      ? ($fetch(`${siteCDN}/api/decrypt-key`, {
           method: 'POST',
           body: {
             auth,


### PR DESCRIPTION
檢查改動有效，並且在無 siteCDN config 時不造成其他影響