### PR TITLE
fix: [SPMVP-6298] sitemap generate error in customer site

### DIFF
--- a/packages/karbon/src/runtime/api/sitemap.ts
+++ b/packages/karbon/src/runtime/api/sitemap.ts
@@ -117,7 +117,7 @@ export const payloadScopes: ResourceScope[] = [
     query: ListAuthors,
     queryKey: 'users',
 
-    filter: (item: { suspended: boolean }) => !item.suspended,
+    filter: (item: { suspended: boolean; slug: string }) => !item.suspended && Boolean(item.slug),
   },
   {
     payloadScope: 'tags',


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6298

原因：
Site 中有 slug 為 `null` 的使用者，且 URL 設定使用 slug 做為參數

修復：
sitemap 的 users 資料中移除 slug 為 `null` 的使用者

驗證：
1. 透過 Karbon playground 確認 `/sitemap.xml` 與 `/api/_storipress/sitemap-urls` 正確
2. 打包後安裝至 nuxt3-compatible-layer 專案，確認 `/sitemap.xml` 與 `/api/_storipress/sitemap-urls` 正確
<img width="683" alt="image" src="https://github.com/storipress/karbon/assets/37400982/e1c82fcb-be35-4876-9eec-3b52283299f6">
<img width="1215" alt="image" src="https://github.com/storipress/karbon/assets/37400982/e89c6211-73b5-4430-9c26-8cfe856306ac">
