### PR TITLE
fix: getUserAgent apollo error

### DIFF
--- a/packages/karbon/src/runtime/composables/storipress-base-client.ts
+++ b/packages/karbon/src/runtime/composables/storipress-base-client.ts
@@ -151,7 +151,7 @@ export function createStoripressBaseClient(
 function getUserAgent() {
   if (process.server) {
     const config = getStoripressConfig()
-    return { 'user-agent': config.userAgent ?? 'karbon/1.0.0' }
+    return { 'user-agent': config?.userAgent ?? 'karbon/1.0.0' }
   }
 
   return {}


### PR DESCRIPTION
```
ApolloError: Cannot read properties of null (reading 'userAgent')                                                                                                                                                 下午1:40:19
    at new ApolloError (file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/errors/index.js:26:28)
    at file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/core/QueryManager.js:665:19
    at both (file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/utilities/observables/asyncMap.js:16:53)
    at file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/utilities/observables/asyncMap.js:9:72
    at new Promise (<anonymous>)
    at Object.then (file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/utilities/observables/asyncMap.js:9:24)
    at Object.error (file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/utilities/observables/asyncMap.js:17:49)
    at notifySubscription (/Users/sid/Storipress/shopify-site/node_modules/zen-observable/lib/Observable.js:140:18)
    at onNotify (/Users/sid/Storipress/shopify-site/node_modules/zen-observable/lib/Observable.js:179:3)
    at SubscriptionObserver.error (/Users/sid/Storipress/shopify-site/node_modules/zen-observable/lib/Observable.js:240:7) {
  graphQLErrors: [],
  protocolErrors: [],
  clientErrors: [],
  networkError: TypeError: Cannot read properties of null (reading 'userAgent')
      at getUserAgent (/Users/sid/Storipress/shopify-site/node_modules/@storipress/karbon/dist/shared/karbon.ef5f7ae6.mjs:117:35)
      at /Users/sid/Storipress/shopify-site/node_modules/@storipress/karbon/dist/shared/karbon.ef5f7ae6.mjs:93:21
      at file:///Users/sid/Storipress/shopify-site/node_modules/@apollo/client/link/context/index.js:11:47,
  extraInfo: undefined
}
```