### PR TITLE
fix: [SPMVP-6289] Missing author url and dateModified in NewArticle schema for SEO

### DIFF
--- a/packages/karbon/src/runtime/components/ArticleLayout.vue
+++ b/packages/karbon/src/runtime/components/ArticleLayout.vue
@@ -27,7 +27,7 @@ function resolveLayout(): string {
 
 useProvideArticle(props.article)
 
-useArticleSchemaOrg(useRuntimeConfig())
+useArticleSchemaOrg()
 </script>
 
 <template>

--- a/packages/karbon/src/runtime/components/ArticleLayout.vue
+++ b/packages/karbon/src/runtime/components/ArticleLayout.vue
@@ -27,7 +27,7 @@ function resolveLayout(): string {
 
 useProvideArticle(props.article)
 
-useArticleSchemaOrg()
+useArticleSchemaOrg(useRuntimeConfig())
 </script>
 
 <template>

--- a/packages/karbon/src/runtime/composables/article-schema.ts
+++ b/packages/karbon/src/runtime/composables/article-schema.ts
@@ -2,6 +2,7 @@ import { parse } from 'node-html-parser'
 import { withoutTrailingSlash } from 'ufo'
 import type { UseArticleReturn as Article } from '../types'
 import { defineArticle, defineOrganization, definePerson, useResourcePageMeta, useSchemaOrg, useSite } from '#imports'
+import type { ResourcePageContext } from '#build/storipress-urls.mjs'
 import urls from '#build/storipress-urls.mjs'
 
 export function useArticleSchemaOrg() {
@@ -20,6 +21,7 @@ export function useArticleSchemaOrg() {
 }
 
 type PageMeta = NonNullable<ReturnType<typeof useResourcePageMeta>['value']>
+const invalidContext = { identity: 'invalid', prefix: '', resource: 'invalid' } as unknown as ResourcePageContext
 
 function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>) {
   const runtimeConfig = useRuntimeConfig()
@@ -32,7 +34,7 @@ function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>) 
       familyName: last_name,
       givenName: first_name,
       name: full_name,
-      sameAs: [withoutTrailingSlash(siteUrl) + urls.author.toURL(author, urls.author._context!)],
+      sameAs: [withoutTrailingSlash(siteUrl) + urls.author.toURL(author, urls.author._context ?? invalidContext)],
     })
   })
   const doc = parse(article.html || '')

--- a/packages/karbon/src/runtime/composables/article-schema.ts
+++ b/packages/karbon/src/runtime/composables/article-schema.ts
@@ -1,8 +1,11 @@
 import { parse } from 'node-html-parser'
+import { withoutTrailingSlash } from 'ufo'
+import type { RuntimeConfig } from 'nuxt/schema'
 import type { UseArticleReturn as Article } from '../types'
 import { defineArticle, defineOrganization, definePerson, useResourcePageMeta, useSchemaOrg, useSite } from '#imports'
+import urls from '#build/storipress-urls.mjs'
 
-export function useArticleSchemaOrg() {
+export function useArticleSchemaOrg(runtimeConfig: RuntimeConfig) {
   const pageMeta = useResourcePageMeta()
   const site = useSite()
 
@@ -12,14 +15,15 @@ export function useArticleSchemaOrg() {
         name: () => site.value?.name || '',
         logo: () => site.value?.logo?.url,
       }),
-      getDefineArticle(pageMeta.value, site),
+      getDefineArticle(pageMeta.value, site, runtimeConfig),
     ])
   }
 }
 
 type PageMeta = NonNullable<ReturnType<typeof useResourcePageMeta>['value']>
 
-function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>) {
+function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>, runtimeConfig: RuntimeConfig) {
+  const siteUrl = runtimeConfig.public.siteUrl as string
   const article: Article = pageMeta.meta
   const authors = article.authors.map((author) => {
     const { first_name, last_name, full_name } = author
@@ -28,6 +32,7 @@ function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>) 
       familyName: last_name,
       givenName: first_name,
       name: full_name,
+      sameAs: [withoutTrailingSlash(siteUrl) + urls.author.toURL(author, urls.author._context!)],
     })
   })
   const doc = parse(article.html || '')
@@ -56,7 +61,7 @@ function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>) 
       '@id': pageMeta.route,
     },
     articleBody: article.plaintext,
-    authors,
+    author: authors,
     image,
     datePublished: article.published_at,
   })

--- a/packages/karbon/src/runtime/composables/article-schema.ts
+++ b/packages/karbon/src/runtime/composables/article-schema.ts
@@ -1,11 +1,10 @@
 import { parse } from 'node-html-parser'
 import { withoutTrailingSlash } from 'ufo'
-import type { RuntimeConfig } from 'nuxt/schema'
 import type { UseArticleReturn as Article } from '../types'
 import { defineArticle, defineOrganization, definePerson, useResourcePageMeta, useSchemaOrg, useSite } from '#imports'
 import urls from '#build/storipress-urls.mjs'
 
-export function useArticleSchemaOrg(runtimeConfig: RuntimeConfig) {
+export function useArticleSchemaOrg() {
   const pageMeta = useResourcePageMeta()
   const site = useSite()
 
@@ -15,14 +14,15 @@ export function useArticleSchemaOrg(runtimeConfig: RuntimeConfig) {
         name: () => site.value?.name || '',
         logo: () => site.value?.logo?.url,
       }),
-      getDefineArticle(pageMeta.value, site, runtimeConfig),
+      getDefineArticle(pageMeta.value, site),
     ])
   }
 }
 
 type PageMeta = NonNullable<ReturnType<typeof useResourcePageMeta>['value']>
 
-function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>, runtimeConfig: RuntimeConfig) {
+function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>) {
+  const runtimeConfig = useRuntimeConfig()
   const siteUrl = runtimeConfig.public.siteUrl as string
   const article: Article = pageMeta.meta
   const authors = article.authors.map((author) => {
@@ -64,5 +64,6 @@ function getDefineArticle(pageMeta: PageMeta, site: ReturnType<typeof useSite>, 
     author: authors,
     image,
     datePublished: article.published_at,
+    dateModified: article.updated_at,
   })
 }

--- a/packages/karbon/src/runtime/types.ts
+++ b/packages/karbon/src/runtime/types.ts
@@ -205,6 +205,7 @@ export interface Article {
   id: string
   blurb?: string | null
   published_at?: any | null
+  updated_at?: any | null
   slug: string
   title: string
   featured: boolean

--- a/packages/karbon/src/runtime/types.ts
+++ b/packages/karbon/src/runtime/types.ts
@@ -205,7 +205,7 @@ export interface Article {
   id: string
   blurb?: string | null
   published_at?: any | null
-  updated_at?: any | null
+  updated_at?: string | null
   slug: string
   title: string
   featured: boolean


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6289

改動：
修復 author 的錯誤與增加 url 設定


驗證：
<img width="1436" alt="image" src="https://github.com/storipress/karbon/assets/37400982/78a8e64f-2181-4a9d-ba25-defd699bc16f">
