### PR TITLE
fix: [SPMVP-5737] Dark mode issue with karbon article template

### DIFF
--- a/packages/karbon/src/cli/bundle/index.ts
+++ b/packages/karbon/src/cli/bundle/index.ts
@@ -102,6 +102,7 @@ export async function bundle(path: string, vuefileName: string, layoutName: stri
               corePlugins: {
                 preflight: false,
               },
+              darkMode: ['class', '.force-use-dark-mode'],
             },
           }),
         ],


### PR DESCRIPTION
## Jira

https://storipress-media.atlassian.net/browse/SPMVP-5737

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause

1. Karbon 上傳的 preview template 預設使用 media 判斷 dark mode
2. Preview 頁面引入了 tailwind Play CDN 後覆蓋了設定

[//]: # 'Why the bug happen?'

## Purpose

正常預覽文章

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [ ] reader-facing?
- [x] publisher-facing?
- [ ] developer-facing?

## How did you fix it?

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

https://github.com/storipress/manager-next/pull/1748

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

1. 使用 Karbon 上傳 template
2. 透過 Preview 顯示正確

## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)
![image](https://github.com/storipress/manager-next/assets/37400982/34835d36-43f8-45d2-a5bf-22b8cedcb8b6)
