### PR TITLE
fix: [SPMVP-6421] [SPMVP-6422] [SPMVP-6424] [SPMVP-6423] seo meta issues

### DIFF
--- a/packages/karbon/package.json
+++ b/packages/karbon/package.json
@@ -133,6 +133,7 @@
     "cross-fetch": "^4.0.0",
     "defu": "^6.1.2",
     "destr": "^2.0.1",
+    "entities": "^4.5.0",
     "events": "^3.3.0",
     "execa": "^8.0.1",
     "fast-deep-equal": "^3.1.3",

--- a/packages/karbon/src/runtime/api/desk.ts
+++ b/packages/karbon/src/runtime/api/desk.ts
@@ -1,3 +1,4 @@
+import { destr } from 'destr'
 import { gql } from '@apollo/client/core/index.js'
 import { useStoripressClient } from '../composables/storipress-client'
 
@@ -94,12 +95,42 @@ export async function listDesks() {
   const client = useStoripressClient()
   const { data } = await client.query({ query: ListDesks })
 
-  return data.desks
+  return data.desks.map((desk: Record<string, string>) => ({ ...desk, deskSEO: resolveSEO(desk.seo, desk.name) }))
 }
 
 export async function getDesk(id: string) {
   const client = useStoripressClient()
   const { data } = await client.query({ query: GetDesk, variables: { id } })
+  const desk = data.desk
 
-  return data.desk
+  return { ...desk, deskSEO: resolveSEO(desk.seo, desk.name) }
+}
+
+export interface SEOItem {
+  matched: boolean
+  title: string
+  description: null | string
+}
+function resolveSEO(seoString: string, deskName: string) {
+  const defaultSeo = {
+    meta: {
+      matched: true,
+      title: deskName,
+      description: null,
+    } as SEOItem,
+    og: {
+      matched: false,
+      title: deskName,
+      description: null,
+    } as SEOItem,
+  }
+
+  const seo = destr<typeof defaultSeo>(seoString) ?? defaultSeo
+  const meta = seo.meta
+  const og = seo.og.matched ? seo.meta : seo.og
+
+  meta.description ??= `Articles for ${deskName}`
+  og.description ??= meta.description
+
+  return { meta, og }
 }

--- a/packages/karbon/src/runtime/composables/article-filter.ts
+++ b/packages/karbon/src/runtime/composables/article-filter.ts
@@ -3,7 +3,7 @@ import { useNuxtApp } from '#imports'
 export function useArticleFilter() {
   const { $entities } = useNuxtApp()
 
-  return (html: string) => {
+  return (html: string): string => {
     if (!html) {
       return ''
     }

--- a/packages/karbon/src/runtime/composables/article-schema.ts
+++ b/packages/karbon/src/runtime/composables/article-schema.ts
@@ -29,6 +29,7 @@ export function useArticleSchemaOrg() {
 
   const pageMeta = useResourcePageMeta()
   const site = useSite()
+  if (pageMeta.value?.type !== 'article') return
 
   if (pageMeta.value) {
     const nuxtApp = useNuxtApp()

--- a/packages/karbon/src/runtime/composables/page-meta.ts
+++ b/packages/karbon/src/runtime/composables/page-meta.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import { useCurrentElement, whenever } from '@vueuse/core'
 import type { EventName } from '../api/track'
-import type { UseArticleReturn as Article } from '../types'
+import type { UseArticleReturn as Article, Resources } from '../types'
 import { useSEO } from './seo'
 import { useStaticState } from './storipress-payload'
 import {
@@ -121,7 +121,7 @@ export function setupPage<Type extends PageType>({ type, seo = true }: SetupPage
   })
 
   if (seo && meta.value) {
-    useSEO(meta.value)
+    useSEO(meta.value, undefined, pageMeta.value?.type as Resources)
   }
 
   if (type === 'author') {

--- a/packages/karbon/src/runtime/composables/seo.ts
+++ b/packages/karbon/src/runtime/composables/seo.ts
@@ -44,8 +44,10 @@ function createFirstFound(paths: string[][]) {
 
 const TITLE = [['seo', 'meta', 'title'], ['title']]
 const DESCRIPTION = [['seo', 'meta', 'description'], ['plaintext']]
+const DESK_DESCRIPTION = [['deskSEO', 'meta', 'description']]
 const OG_TITLE = [['seo', 'og', 'title'], ...TITLE]
 const OG_DESCRIPTION = [['seo', 'og', 'description'], ...DESCRIPTION]
+const OG_DESK_DESCRIPTION = [['deskSEO', 'og', 'description']]
 const OG_IMAGE = [['seo', 'ogImage'], ['headline'], ['cover', 'url']]
 const AUTHOR_BIO = [['bio']]
 
@@ -126,6 +128,7 @@ export function defineSEOPreset(
 export const basic = defineSEOPreset(({ twitterCard = 'summary_large_image' }) => [
   simpleSEO(TITLE, (title: string | undefined) => isDefined(title) && { title }),
   simpleSEO(DESCRIPTION, (description) => isDefined(description) && { description }),
+  simpleSEO(DESK_DESCRIPTION, (description) => isDefined(description) && { description }),
   simpleSEO(AUTHOR_BIO, (authorBio) => {
     const bio = truncate(authorBio, {
       length: 150,
@@ -135,6 +138,7 @@ export const basic = defineSEOPreset(({ twitterCard = 'summary_large_image' }) =
   }),
   simpleSEO(OG_TITLE, (ogTitle) => isDefined(ogTitle) && { ogTitle }),
   simpleSEO(OG_DESCRIPTION, (ogDescription) => isDefined(ogDescription) && { ogDescription }),
+  simpleSEO(OG_DESK_DESCRIPTION, (ogDescription) => isDefined(ogDescription) && { ogDescription }),
   simpleSEO(OG_IMAGE, (ogImage) => isDefined(ogImage) && { ogImage }),
   simpleSEO(OG_TITLE, (ogTitle) => isDefined(ogTitle) && { twitterTitle: ogTitle }),
   simpleSEO(OG_DESCRIPTION, (ogDescription) => isDefined(ogDescription) && { twitterDescription: ogDescription }),

--- a/packages/karbon/src/runtime/composables/seo.ts
+++ b/packages/karbon/src/runtime/composables/seo.ts
@@ -7,6 +7,7 @@ import { watchSyncEffect } from 'vue'
 import truncate from 'lodash.truncate'
 import { resolveURL, withTrailingSlash } from 'ufo'
 import type { BaseMeta, Resources } from '../types'
+import { invalidContext } from '../utils/invalid-context'
 import { useHead, useNuxtApp, useSeoMeta } from '#imports'
 import urls from '#build/storipress-urls.mjs'
 
@@ -137,14 +138,16 @@ const typeMap: Record<ResourceType, Resources> = {
   Tag: 'tag',
 }
 function getResourceURL(input: RawSEOInput): string | undefined {
+  // skipcq: JS-W1043
   const typeName: ResourceType = input.__typename || '_'
   const resourceType = typeMap[typeName]
   const resourceUrls = urls[resourceType]
-  if (!resourceUrls?.enable) return
+  if (!resourceUrls?.enable) return undefined
 
   const runtimeConfig = useRuntimeConfig()
+  // skipcq: JS-W1043
   const siteUrl = (runtimeConfig?.public?.siteUrl as string) || '/'
-  const url = resourceUrls.toURL(input as BaseMeta, resourceUrls._context!)
+  const url = resourceUrls.toURL(input as BaseMeta, resourceUrls._context ?? invalidContext)
   return withTrailingSlash(resolveURL(siteUrl, url))
 }
 

--- a/packages/karbon/src/runtime/composables/seo.ts
+++ b/packages/karbon/src/runtime/composables/seo.ts
@@ -4,6 +4,7 @@ import type { MetaFlatInput } from '@zhead/schema'
 import type { MaybeRefOrGetter } from '@vueuse/core'
 import { isDefined, toRef } from '@vueuse/core'
 import { watchSyncEffect } from 'vue'
+import truncate from 'lodash.truncate'
 import { useHead, useNuxtApp, useSeoMeta } from '#imports'
 
 interface SEOItem {
@@ -46,6 +47,7 @@ const DESCRIPTION = [['seo', 'meta', 'description'], ['plaintext']]
 const OG_TITLE = [['seo', 'og', 'title'], ...TITLE]
 const OG_DESCRIPTION = [['seo', 'og', 'description'], ...DESCRIPTION]
 const OG_IMAGE = [['seo', 'ogImage'], ['headline'], ['cover', 'url']]
+const AUTHOR_BIO = [['bio']]
 
 function createSEO<T>(pick: (input: RawSEOInput) => T, map: (input: T) => MetaInput | undefined | false) {
   return (input: RawSEOInput) => {
@@ -124,6 +126,13 @@ export function defineSEOPreset(
 export const basic = defineSEOPreset(({ twitterCard = 'summary_large_image' }) => [
   simpleSEO(TITLE, (title: string | undefined) => isDefined(title) && { title }),
   simpleSEO(DESCRIPTION, (description) => isDefined(description) && { description }),
+  simpleSEO(AUTHOR_BIO, (authorBio) => {
+    const bio = truncate(authorBio, {
+      length: 150,
+      separator: /,? +/,
+    })
+    return isDefined(authorBio) && { description: bio, ogDescription: bio }
+  }),
   simpleSEO(OG_TITLE, (ogTitle) => isDefined(ogTitle) && { ogTitle }),
   simpleSEO(OG_DESCRIPTION, (ogDescription) => isDefined(ogDescription) && { ogDescription }),
   simpleSEO(OG_IMAGE, (ogImage) => isDefined(ogImage) && { ogImage }),

--- a/packages/karbon/src/runtime/plugins/html-attribute.ts
+++ b/packages/karbon/src/runtime/plugins/html-attribute.ts
@@ -1,11 +1,14 @@
-import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, getSite } from '#imports'
+import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, getSite, useNuxtApp } from '#imports'
 
 const setHtmlLang = defineNuxtRouteMiddleware(async () => {
+  const nuxt = useNuxtApp()
   const site = await getSite()
-  useHead({
-    htmlAttrs: {
-      lang: site.lang,
-    },
+  nuxt.runWithContext(() => {
+    useHead({
+      htmlAttrs: {
+        lang: site.lang,
+      },
+    })
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,6 +3382,7 @@ __metadata:
     cross-fetch: ^4.0.0
     defu: ^6.1.2
     destr: ^2.0.1
+    entities: ^4.5.0
     eslint: 8.49.0
     eslint-config-prettier: 9.0.0
     eslint-plugin-prettier: 5.0.0
@@ -7498,7 +7499,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6421
https://storipress-media.atlassian.net/browse/SPMVP-6422
https://storipress-media.atlassian.net/browse/SPMVP-6424
https://storipress-media.atlassian.net/browse/SPMVP-6423

改動：
1. author page、desk page 增加 SEO meta
2. 修復在 article 以外的頁面，使用到 `<ArticleLayout />` 造成的 500 error
3. 增加 HandlerContext 提供給 SEOHandler 使用

驗證：
1. 開啟 author page 檢查 meta

> 備註：
> 為了測試截斷效果，截圖中為 120 字截斷，實際上設定為 150 字截斷

2. 開啟 desk page 檢查 meta 


5. 開啟 resource page 檢查 `og:url`, `og:type`
![image](https://github.com/storipress/karbon/assets/37400982/40a80d8f-c7f4-49e5-b0bf-95a3c726f824)
![image](https://github.com/storipress/karbon/assets/37400982/dc700a2c-3aa7-46af-9250-c2604d4103f6)
![image](https://github.com/storipress/karbon/assets/37400982/162e9013-ed9b-44c5-8d96-41a03599951c)
![image](https://github.com/storipress/karbon/assets/37400982/9fe22563-189e-471a-bc71-07ead9512a96)

6. 檢查 author, desk 頁面的 twitter meta
![image](https://github.com/storipress/karbon/assets/37400982/50f2e0f0-ce44-4cd8-8e11-590f69be2928)
![image](https://github.com/storipress/karbon/assets/37400982/368f4f83-4beb-468c-8858-7fe31a57d4ac)
