### PR TITLE
fix: only set paragraph num in first paragraph

### DIFF
--- a/packages/karbon/src/runtime/article/components/ArticleBody.vue
+++ b/packages/karbon/src/runtime/article/components/ArticleBody.vue
@@ -49,11 +49,22 @@ const { state: articleSegments, execute } = useAsyncState<Segment[]>(
 )
 
 const wrapArticleSegments = computed(() => {
-  let paragraphNum = 0
-  return articleSegments.value.map((item) => ({
-    ...item,
-    paragraphNum: (paragraphNum += item.type === 'p' ? 1 : 0),
-  }))
+  let findedFirst = false
+  return articleSegments.value.map((item) => {
+    if (findedFirst) {
+      return item
+    }
+
+    if (item.type === 'p') {
+      findedFirst = true
+      return {
+        ...item,
+        paragraphNum: 1,
+      }
+    }
+
+    return item
+  })
 })
 
 watch(


### PR DESCRIPTION
## Jira

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

https://storipress-media.atlassian.net/jira/software/projects/SPMVP/boards/1?selectedIssue=SPMVP-6477

## Root cause

[//]: # 'Why the bug happen?'

set the paragraph num to img

## Purpose

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

only set at first paragraph

### For who

- [ ] reader-facing?
- [ ] publisher-facing?
- [x] developer-facing?

## How did you fix it?

[//]: # 'Give a brief for the changes you made'

check if had set paragraph num

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

1. copy code to nuxt3-compatible-layer to replace node_modules karbon code
2. yarn dev
3. open console to check paragraph num only set once 
<img width="1440" alt="image" src="https://github.com/storipress/karbon/assets/11523578/806b0e18-b5c4-412b-a829-a6442dbf6429">


## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the issue fixed
- [x] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [x] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [x] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [x] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
