### PR TITLE
feat: reduce karbon generated payload size

### DIFF
--- a/packages/karbon/src/runtime/api/article.ts
+++ b/packages/karbon/src/runtime/api/article.ts
@@ -15,7 +15,7 @@ import { splitArticle } from '../lib/split-article'
 import { getStoripressConfig } from '../composables/storipress-base-client'
 import { verboseInvariant } from '../utils/verbose-invariant'
 import type { PaidContent, RawArticleLike, _NormalizeArticle } from './normalize-article'
-import { normalizeArticle } from './normalize-article'
+import { filterArticleProperties, normalizeArticle } from './normalize-article'
 
 export type { NormalizeArticle, PaidContent } from './normalize-article'
 
@@ -267,7 +267,10 @@ export async function listArticles(filter?: TypesenseFilter) {
     // `destr` is workaround for fetch adapter not automatically parse response
     const searchResult = destr<SearchResponse<RawArticleLike>>(await documents.search(getSearchQuery(page, filter), {}))
     const currentPageArticles =
-      searchResult?.hits?.map(({ document }) => normalizeArticle(document as RawArticleLike)) ?? []
+      searchResult?.hits?.map(({ document }) => {
+        const article = normalizeArticle(document as RawArticleLike)
+        return filterArticleProperties(article)
+      }) ?? []
     articles.push(...currentPageArticles)
 
     hasMore = searchResult.found > searchResult.page * PER_PAGE

--- a/packages/karbon/src/runtime/api/normalize-article.ts
+++ b/packages/karbon/src/runtime/api/normalize-article.ts
@@ -15,6 +15,11 @@ export interface RawUserLike {
 
 export interface RawArticleLike {
   id: string
+  sid?: string
+  slug: string
+  featured: boolean
+  order: number
+  updated_at: number
   title: string
   blurb: string
   bio: string
@@ -114,4 +119,39 @@ export function unwrapParagraph(input: string): string {
   }
 
   return input.replace(/^<p>/, '').replace(/<\/p>$/, '')
+}
+
+// PropertiesList: 'headline', 'title', 'blurb', 'desk', 'deskUrl', 'url', 'authors', 'time'
+// headline: article.cover?.url
+// deskUrl: article.desk && `/desks/${getDesk(article.desk).slug}`
+// url: slug
+// time: new Date(article.published_at)
+const propertiesToKeep = [
+  'featured',
+  'order',
+  'slug',
+  'updated_at',
+  'id',
+  'plan',
+  'bio',
+  'published_at',
+  'title',
+  'blurb',
+  'seo',
+  'plaintext',
+  'cover',
+  'authors',
+  'desk',
+  'tags',
+] as const
+type PropertiesToKeep = (typeof propertiesToKeep)[number]
+
+export function filterArticleProperties(article: _NormalizeArticle): Pick<_NormalizeArticle, PropertiesToKeep> {
+  const filteredArticle = { ...article }
+  for (const property in article) {
+    if (!propertiesToKeep.includes(property as PropertiesToKeep)) {
+      Reflect.deleteProperty(filteredArticle, property)
+    }
+  }
+  return filteredArticle as Pick<_NormalizeArticle, PropertiesToKeep>
 }

--- a/packages/karbon/src/runtime/api/normalize-article.ts
+++ b/packages/karbon/src/runtime/api/normalize-article.ts
@@ -32,6 +32,7 @@ export interface RawArticleLike {
   tags: ArticleTag[]
   desk: ArticleDesk
   published_at: string | number
+  pathnames: string[]
 }
 
 export interface PaidContent {
@@ -143,6 +144,7 @@ const propertiesToKeep = [
   'authors',
   'desk',
   'tags',
+  'pathnames',
 ] as const
 type PropertiesToKeep = (typeof propertiesToKeep)[number]
 


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6869

![image](https://github.com/storipress/karbon/assets/37400982/7b9edc1c-66b8-42d4-887a-ac73868f0797)

1. Install in Generator after packing, check that the homepage functions and displays normally.
2. Download /_payload.json and check the capacity before and after the changes.