### PR TITLE
feat: [SPMVP-6864] add hooks for measure typesense response time

### DIFF
--- a/packages/karbon/src/module.ts
+++ b/packages/karbon/src/module.ts
@@ -42,12 +42,19 @@ import { getResources, payloadScopes } from './runtime/api/sitemap'
 import telemetry from './modules/telemetry'
 import feed from './modules/feed'
 import instantsearch from './modules/instantsearch'
-import type { RequestContext, ResponseContext } from './runtime/composables/storipress-base-client'
+import type {
+  RequestContext,
+  ResponseContext,
+  SearchRequestContext,
+  SearchResponseContext,
+} from './runtime/composables/storipress-base-client'
 
 declare module '#app' {
   interface RuntimeNuxtHooks {
     'karbon:request': (ctx: RequestContext) => HookResult
     'karbon:response': (ctx: ResponseContext) => HookResult
+    'karbon:searchRequest': (ctx: SearchRequestContext) => HookResult
+    'karbon:searchResponse': (ctx: SearchResponseContext) => HookResult
   }
 }
 
@@ -55,6 +62,8 @@ declare module 'nitropack' {
   interface NitroRuntimeHooks {
     'karbon:request': (ctx: RequestContext) => void
     'karbon:response': (ctx: ResponseContext) => void
+    'karbon:searchRequest': (ctx: SearchRequestContext) => HookResult
+    'karbon:searchResponse': (ctx: SearchResponseContext) => HookResult
   }
 }
 

--- a/packages/karbon/src/module.ts
+++ b/packages/karbon/src/module.ts
@@ -58,7 +58,8 @@ declare module '#app' {
   }
 }
 
-declare module 'nitropack' {
+// reference: https://github.com/harlan-zw/nuxt-simple-sitemap/blob/324719dff6bf5c4214a093adbac4d5105d35bcb3/src/module.ts#L236
+declare module 'nitropack/dist/runtime/types' {
   interface NitroRuntimeHooks {
     'karbon:request': (ctx: RequestContext) => void
     'karbon:response': (ctx: ResponseContext) => void

--- a/packages/karbon/src/runtime/composables/storipress-base-client.ts
+++ b/packages/karbon/src/runtime/composables/storipress-base-client.ts
@@ -5,6 +5,7 @@ import { fetch } from 'cross-fetch'
 import { withHttps } from 'ufo'
 import { Hookable } from 'hookable'
 import type { Subscription } from 'zen-observable-ts'
+import type { SearchParams, SearchParamsWithPreset } from 'typesense/lib/Typesense/Documents'
 import type { ModuleRuntimeConfig } from '../types'
 
 let c: any = null
@@ -23,11 +24,31 @@ export interface ResponseContext {
   data: any
 }
 
+export interface SearchRequestContext {
+  id: string
+  groupId: string
+  name: string
+  query: SearchParams | SearchParamsWithPreset
+  site: string
+  isFirstRequest: boolean
+  requestTime: number
+  groupStartTime: number
+}
+
+export interface SearchResponseContext extends SearchRequestContext {
+  type: 'error' | 'complete'
+  hasMore: boolean
+  responseTime: number
+  error?: Error
+}
+
 type HookResult = Promise<void> | void
 
 export const _karbonClientHooks = new Hookable<{
   'karbon:request': (ctx: RequestContext) => HookResult
   'karbon:response': (ctx: ResponseContext) => HookResult
+  'karbon:searchRequest': (ctx: SearchRequestContext) => HookResult
+  'karbon:searchResponse': (ctx: SearchResponseContext) => HookResult
 }>()
 
 export const storipressConfigCtx = {

--- a/packages/karbon/src/runtime/plugins/client-hooks.ts
+++ b/packages/karbon/src/runtime/plugins/client-hooks.ts
@@ -9,4 +9,11 @@ export default defineNuxtPlugin((nuxt) => {
   _karbonClientHooks.hook('karbon:response', async (ctx) => {
     await nuxt.hooks.callHookParallel('karbon:response', ctx)
   })
+  _karbonClientHooks.hook('karbon:searchRequest', async (ctx) => {
+    await nuxt.hooks.callHookParallel('karbon:searchRequest', ctx)
+  })
+
+  _karbonClientHooks.hook('karbon:searchResponse', async (ctx) => {
+    await nuxt.hooks.callHookParallel('karbon:searchResponse', ctx)
+  })
 })

--- a/packages/karbon/src/runtime/server/plugins/hook.ts
+++ b/packages/karbon/src/runtime/server/plugins/hook.ts
@@ -11,4 +11,10 @@ export default defineNitroPlugin((nitro) => {
   hooks.hook('karbon:response', (ctx) => {
     return nitro.hooks.callHookParallel('karbon:response', ctx)
   })
+  hooks.hook('karbon:searchRequest', (ctx) => {
+    return nitro.hooks.callHookParallel('karbon:searchRequest', ctx)
+  })
+  hooks.hook('karbon:searchResponse', (ctx) => {
+    return nitro.hooks.callHookParallel('karbon:searchResponse', ctx)
+  })
 })

--- a/packages/playground/plugins/listener.server.ts
+++ b/packages/playground/plugins/listener.server.ts
@@ -6,4 +6,10 @@ export default defineNuxtPlugin(() => {
   nuxt.hooks.hook('karbon:response', (ctx) => {
     console.log('nuxt response', ctx)
   })
+  nuxt.hooks.hook('karbon:searchRequest', (ctx) => {
+    console.log('nuxt searchRequest', ctx)
+  })
+  nuxt.hooks.hook('karbon:searchResponse', (ctx) => {
+    console.log('nuxt searchResponse', ctx)
+  })
 })

--- a/packages/playground/server/plugins/listener.ts
+++ b/packages/playground/server/plugins/listener.ts
@@ -7,4 +7,10 @@ export default defineNitroPlugin((nitro) => {
   nitro.hooks.hook('karbon:response', (ctx) => {
     console.log('nitro response', ctx)
   })
+  nitro.hooks.hook('karbon:searchRequest', (ctx) => {
+    console.log('nitro searchRequest', ctx)
+  })
+  nitro.hooks.hook('karbon:searchResponse', (ctx) => {
+    console.log('nitro searchResponse', ctx)
+  })
 })


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6864

檢查 playground 與 generator-v2 可以使用 `NitroApp.hooks.hook('karbon:searchResponse', () => { // ... })` 監聽事件並取得相關資料
![image](https://github.com/storipress/karbon/assets/37400982/9d8e9b53-5f3a-45e6-b5d8-93fc0dc399ce)
