### PR TITLE
fix: payload __map.json with special character slugs

### DIFF
--- a/packages/karbon/src/runtime/composables/resources.ts
+++ b/packages/karbon/src/runtime/composables/resources.ts
@@ -197,11 +197,12 @@ function getContextFor(type: Resources | string) {
 }
 
 async function convertToId(scope: PayloadScope, resourceID: any): Promise<string | null> {
-  const { id, slug, sid } = resourceID
+  const { id, slug: _slug, sid } = resourceID
   if (id) {
     return id
   }
   const idComparisonMap = await loadStoripressPayload<IdComparisonMap>(scope, '__map', true)
+  const slug = decodeURIComponent(_slug ?? '')
   return (slug ? idComparisonMap.slugs[slug] : idComparisonMap.sids[sid]) ?? null
 }
 

--- a/packages/karbon/src/runtime/routes/payload-handler.ts
+++ b/packages/karbon/src/runtime/routes/payload-handler.ts
@@ -95,7 +95,8 @@ export function definePayloadHandler<T extends Identifiable>({
       const items = await listAll(true)
       const initial = { slugs: {}, sids: {} }
 
-      return items.reduce((target, { id, slug, sid }) => {
+      return items.reduce((target, { id, slug: _slug, sid }) => {
+        const slug = decodeURIComponent(_slug ?? '')
         slug && Object.assign(target.slugs, { [slug]: id })
         sid && Object.assign(target.sids, { [sid]: id })
         return target


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6990

Tophat:
1. Testing in the playground can open the page correctly
2. After pack, the page can be opened correctly when tested in generator-v2.
3. Check `/_storipress/posts/__map.json` for correct decode

![image](https://github.com/storipress/karbon/assets/37400982/941ba470-85ed-4480-9857-a67396584f7a)
