### PR TITLE
fix: [SPMVP-6981] blurb is not use as meta description

### DIFF
--- a/packages/karbon/src/runtime/composables/seo.ts
+++ b/packages/karbon/src/runtime/composables/seo.ts
@@ -49,7 +49,7 @@ function createFirstFound(paths: string[][]) {
 
 const TITLE = [['seo', 'meta', 'title'], ['title'], ['name']]
 const DESK_DESCRIPTION = [['deskSEO', 'meta', 'description']]
-const DESCRIPTION = [['seo', 'meta', 'description'], ['plaintext'], ...DESK_DESCRIPTION]
+const DESCRIPTION = [['blurb'], ['seo', 'meta', 'description'], ['plaintext'], ...DESK_DESCRIPTION]
 const OG_TITLE = [['seo', 'og', 'title'], ...TITLE]
 const OG_DESK_DESCRIPTION = [['deskSEO', 'og', 'description']]
 const OG_DESCRIPTION = [['seo', 'og', 'description'], ...OG_DESK_DESCRIPTION, ...DESCRIPTION]

--- a/packages/karbon/src/runtime/composables/seo.ts
+++ b/packages/karbon/src/runtime/composables/seo.ts
@@ -49,7 +49,7 @@ function createFirstFound(paths: string[][]) {
 
 const TITLE = [['seo', 'meta', 'title'], ['title'], ['name']]
 const DESK_DESCRIPTION = [['deskSEO', 'meta', 'description']]
-const DESCRIPTION = [['blurb'], ['seo', 'meta', 'description'], ['plaintext'], ...DESK_DESCRIPTION]
+const DESCRIPTION = [['seo', 'meta', 'description'], ['blurb'], ['plaintext'], ...DESK_DESCRIPTION]
 const OG_TITLE = [['seo', 'og', 'title'], ...TITLE]
 const OG_DESK_DESCRIPTION = [['deskSEO', 'og', 'description']]
 const OG_DESCRIPTION = [['seo', 'og', 'description'], ...OG_DESK_DESCRIPTION, ...DESCRIPTION]


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-6981

Tophat:
1. In the playground, verified that the article meta description prioritizes using the blurb.
2. After running `yarn pack` and checking in other projects, confirmed that the article meta description prioritizes using the blurb.
<img width="522" alt="image" src="https://github.com/storipress/karbon/assets/37400982/649abc4c-21a1-4385-b519-29a47f6f4062">
