### PR TITLE
fix: article page loads more at the bottom when no more articles [SPMVP-6937]

### DIFF
--- a/packages/karbon/src/runtime/components/InfiniteScroll.vue
+++ b/packages/karbon/src/runtime/components/InfiniteScroll.vue
@@ -58,7 +58,7 @@ if (process.client) {
           </CustomFieldScope>
         </slot>
       </template>
-      <slot v-if="loading" name="loading">Loading...</slot>
+      <slot v-if="loading" name="loading" />
     </component>
   </ClientOnly>
 </template>

--- a/packages/karbon/src/runtime/composables/load-more.ts
+++ b/packages/karbon/src/runtime/composables/load-more.ts
@@ -24,7 +24,7 @@ export function useLoadMore<T>(GeneratorSource: () => AsyncGenerator<T>, option?
 
     if (done) {
       preload ? loadMoreEvent.trigger([value]) : loadMoreEvent.trigger(value)
-      list.push(value)
+      value && list.push(value)
       loading.value = false
 
       isDone.value = true


### PR DESCRIPTION
## Jira
https://storipress-media.atlassian.net/browse/SPMVP-6937

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause
<img width="553" alt="截圖 2023-12-26 下午2 01 44" src="https://github.com/storipress/karbon/assets/35054329/6a0a8a75-299b-472c-b90e-be6d9832b74d">
<img width="552" alt="截圖 2023-12-26 下午2 00 49" src="https://github.com/storipress/karbon/assets/35054329/e5fb4b3f-3987-4aa3-8b91-14bb35fbffe1">


[//]: # 'Why the bug happen?'

## Purpose
1. 修正 undefined 被 push 進 list
2. 預設 loading 狀態不顯示 `loading...`

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [ ] reader-facing?
- [x] publisher-facing?
- [ ] developer-facing?

## How did you fix it?

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

1. list 資料正確沒有 undefined ⭕ 
2. 載入時預設不會顯示 `loading...`

<img width="556" alt="截圖 2023-12-26 下午1 58 49" src="https://github.com/storipress/karbon/assets/35054329/82458b6e-1e6f-4112-8ace-c46ba4daf824">


## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [x] I have done a self-review of my own code (comment on code is not required but recommended)
- [x] I did the Tophat steps and confirm the issue fixed
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [x] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [x] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
