### PR TITLE
fix: return 404 if Storipress API return 404

### DIFF
--- a/packages/karbon/src/runtime/composables/resources.ts
+++ b/packages/karbon/src/runtime/composables/resources.ts
@@ -164,7 +164,7 @@ async function resolveResource(resourceID: ResourceID, params?: Record<string, s
 
 async function resolveAsID(resourceID: ResourceID): Promise<string | null> {
   try {
-    return convertToId(KEY_TO_SCOPE[resourceID.type], resourceID)
+    return await convertToId(KEY_TO_SCOPE[resourceID.type], resourceID)
   } catch (error) {
     throw new KarbonError('convertToId fail', { cause: error })
   }

--- a/packages/karbon/src/runtime/composables/resources.ts
+++ b/packages/karbon/src/runtime/composables/resources.ts
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import { useAsyncState } from '@vueuse/core'
 import type { BaseMeta, IdComparisonMap, MetaMap, PayloadScope, ResourceID, Resources } from '../types'
 import { invalidContext } from '../utils/invalid-context'
+import { KarbonError } from '../utils/error'
 import urls from '#build/storipress-urls.mjs'
 import {
   computed,
@@ -144,18 +145,29 @@ function resolveAsRef(key: string, resourceID: ResourceID) {
 }
 
 async function resolveResource(resourceID: ResourceID, params?: Record<string, string>, resourceName?: string) {
-  const { type } = resourceID
-  const resource = resourceName || type
-  const id = await resolveAsID(resourceID)
-  if (!id) {
-    return null
+  try {
+    const { type } = resourceID
+    const resource = resourceName || type
+    const id = await resolveAsID(resourceID)
+    if (!id) {
+      return null
+    }
+    const meta = await getResourceMeta(KEY_TO_SCOPE[type], id)
+    if (!meta) {
+      return null
+    }
+    return resolveFromResourceMeta(resource, meta, params)
+  } catch (error) {
+    throw new KarbonError('resolveResource fail', { cause: error })
   }
-  const meta = await getResourceMeta(KEY_TO_SCOPE[type], id)
-  return resolveFromResourceMeta(resource, meta, params)
 }
 
 async function resolveAsID(resourceID: ResourceID): Promise<string | null> {
-  return convertToId(KEY_TO_SCOPE[resourceID.type], resourceID)
+  try {
+    return convertToId(KEY_TO_SCOPE[resourceID.type], resourceID)
+  } catch (error) {
+    throw new KarbonError('convertToId fail', { cause: error })
+  }
 }
 
 async function resolveFromResourceMeta(type: Resources | string, meta: BaseMeta, params?: Record<string, string>) {
@@ -186,8 +198,9 @@ function resolveFromResourceMetaSync(type: Resources | string, meta: BaseMeta, p
   }
 }
 
-async function getResourceMeta<Meta extends BaseMeta>(scope: PayloadScope, id: string): Promise<Meta> {
+async function getResourceMeta<Meta extends BaseMeta>(scope: PayloadScope, id: string): Promise<Meta | null> {
   const meta = await loadStoripressPayload<Meta>(scope, id)
+  if (typeof meta === 'string') return null
 
   return meta
 }

--- a/packages/karbon/src/runtime/plugins/storipress.ts
+++ b/packages/karbon/src/runtime/plugins/storipress.ts
@@ -37,6 +37,7 @@ const fetchMeta = defineNuxtRouteMiddleware(async (to) => {
   const resourceID = urls[urlKey].getIdentity(to.params as Record<string, string>, ctx, desksMeta)
   const res = await resolveID(resourceID, to.params as Record<string, string>, to.meta.resourceName as string)
   if (!res) {
+    setResponseStatus(event, 404)
     return
   }
 
@@ -54,7 +55,7 @@ const abortIfNoMeta = defineNuxtRouteMiddleware(() => {
       return
     }
 
-    setResponseStatus(404)
+    setResponseStatus(event, 404)
     // skipcq: JS-0045
     return abortNavigation()
   }

--- a/packages/karbon/src/runtime/routes/authors/[name].js.ts
+++ b/packages/karbon/src/runtime/routes/authors/[name].js.ts
@@ -5,6 +5,7 @@ import { defineCachedEventHandler } from '#imports'
 
 export default defineCachedEventHandler(
   definePayloadHandler({
+    payloadScope: 'authors',
     listAll: listAuthors,
     getOne: getAuthor,
   }),

--- a/packages/karbon/src/runtime/routes/desks/[name].js.ts
+++ b/packages/karbon/src/runtime/routes/desks/[name].js.ts
@@ -5,6 +5,7 @@ import { defineCachedEventHandler } from '#imports'
 
 export default defineCachedEventHandler(
   definePayloadHandler({
+    payloadScope: 'desks',
     listAll: listDesks,
     getOne: getDesk,
   }),

--- a/packages/karbon/src/runtime/routes/posts/[name].js.ts
+++ b/packages/karbon/src/runtime/routes/posts/[name].js.ts
@@ -21,6 +21,7 @@ interface CacheEntry<T = any> {
 
 export default defineCachedEventHandler(
   definePayloadHandler({
+    payloadScope: 'posts',
     listAll: cachedFunction(listArticles, {
       name: 'article-list',
       swr: true,

--- a/packages/karbon/src/runtime/routes/tags/[name].js.ts
+++ b/packages/karbon/src/runtime/routes/tags/[name].js.ts
@@ -5,6 +5,7 @@ import { defineCachedEventHandler } from '#imports'
 
 export default defineCachedEventHandler(
   definePayloadHandler({
+    payloadScope: 'tags',
     listAll: listTags,
     getOne: getTag,
   }),

--- a/packages/karbon/src/runtime/utils/error.ts
+++ b/packages/karbon/src/runtime/utils/error.ts
@@ -1,0 +1,35 @@
+import { symbol } from 'zod'
+import type { PayloadScope } from '../types'
+
+export class KarbonError extends Error {
+  name: string = 'KarbonError'
+  httpStatus: number = 500
+
+  constructor(message: string, errorOptions?: ErrorOptions) {
+    super(message, errorOptions)
+  }
+
+  setHttpStatus(code: number) {
+    this.httpStatus = code
+  }
+}
+
+export function isKarbonError(error: unknown): error is KarbonError {
+  return error instanceof KarbonError
+}
+
+export const KarbonErrorSymbol = Symbol('KarbonError')
+
+export interface KarbonErrorMeta {
+  payloadScope?: PayloadScope
+  function?: string
+  symbol: typeof KarbonErrorSymbol
+  httpStatus?: number
+  message: string
+  stack?: string
+  error?: any
+}
+
+export function isKarbonErrorMeta(error: any): error is KarbonErrorMeta {
+  return error?.symbol === KarbonErrorSymbol
+}

--- a/packages/karbon/src/runtime/utils/error.ts
+++ b/packages/karbon/src/runtime/utils/error.ts
@@ -1,13 +1,8 @@
-import { symbol } from 'zod'
 import type { PayloadScope } from '../types'
 
 export class KarbonError extends Error {
-  name: string = 'KarbonError'
-  httpStatus: number = 500
-
-  constructor(message: string, errorOptions?: ErrorOptions) {
-    super(message, errorOptions)
-  }
+  name = 'KarbonError'
+  httpStatus = 500
 
   setHttpStatus(code: number) {
     this.httpStatus = code
@@ -27,9 +22,10 @@ export interface KarbonErrorMeta {
   httpStatus?: number
   message: string
   stack?: string
-  error?: any
+  error?: unknown
 }
 
-export function isKarbonErrorMeta(error: any): error is KarbonErrorMeta {
-  return error?.symbol === KarbonErrorSymbol
+export function isKarbonErrorMeta(error: unknown): error is KarbonErrorMeta {
+  const _error = error as KarbonErrorMeta
+  return _error?.symbol === KarbonErrorSymbol
 }

--- a/packages/karbon/src/runtime/utils/error.ts
+++ b/packages/karbon/src/runtime/utils/error.ts
@@ -13,12 +13,10 @@ export function isKarbonError(error: unknown): error is KarbonError {
   return error instanceof KarbonError
 }
 
-export const KarbonErrorSymbol = Symbol('KarbonError')
-
 export interface KarbonErrorMeta {
+  __isKarbonError: true
   payloadScope?: PayloadScope
   function?: string
-  symbol: typeof KarbonErrorSymbol
   httpStatus?: number
   message: string
   stack?: string
@@ -27,5 +25,5 @@ export interface KarbonErrorMeta {
 
 export function isKarbonErrorMeta(error: unknown): error is KarbonErrorMeta {
   const _error = error as KarbonErrorMeta
-  return _error?.symbol === KarbonErrorSymbol
+  return Boolean(_error.__isKarbonError)
 }


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-7009

1. Return a 404 when the resource is not found.
2. Return the API error code and the original error when there is a payload error.